### PR TITLE
Add config php70

### DIFF
--- a/src/Php70.php
+++ b/src/Php70.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace M6Web\CS\Config;
+
+use PhpCsFixer\Config;
+
+final class Php70 extends Config
+{
+    public function __construct()
+    {
+        parent::__construct('M6Web (PHP 7.0)');
+
+        $this->setRiskyAllowed(true);
+    }
+
+    public function getRules()
+    {
+        $rules = [
+            '@Symfony' => true,
+            'array_syntax' => [
+                'syntax' => 'short',
+            ],
+            'no_unreachable_default_argument_value' => false,
+            'braces' => [
+                'allow_single_line_closure' => true,
+            ],
+            'heredoc_to_nowdoc' => false,
+            'phpdoc_summary' => false,
+        ];
+
+        return $rules;
+    }
+}


### PR DESCRIPTION
## Why
Add a new config for project on `php7.0`.

## How
Copy from `php7.1`.