### PR TITLE
Update php-cs-fixer to 2.8 and fix increment_style deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "friendsofphp/php-cs-fixer": "^2.6"
+        "friendsofphp/php-cs-fixer": "~2.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -26,7 +26,7 @@ final class Php71 extends Config
             ],
             'heredoc_to_nowdoc' => false,
             'phpdoc_summary' => false,
-            'pre_increment' => false,
+            'increment_style' => 'post',
             'yoda_style' => false,
         ];
 


### PR DESCRIPTION
- `pre_increment` is now `increment_style`
- The dependancy is now set to patch level because minors are apparently laravel style major releases