### PR TITLE
Support for php 7.2/7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Create a configuration file `.php_cs` in the root of your project:
 ```php
 <?php
 
-$config = new M6Web\CS\Config\Php71;
+$config = new M6Web\CS\Config\Php72;
 
 $config->getFinder()
     ->in([

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "friendsofphp/php-cs-fixer": "~2.13.0"
+        "friendsofphp/php-cs-fixer": "^2.14"
     },
     "autoload": {
         "psr-4": {

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace M6Web\CS\Config;
+
+use PhpCsFixer\Config;
+
+final class Php72 extends Config
+{
+    public function __construct()
+    {
+        parent::__construct('M6Web (PHP 7.2)');
+
+        $this->setRiskyAllowed(true);
+    }
+
+    public function getRules()
+    {
+        $rules = [
+            '@Symfony' => true,
+            'array_syntax' => [
+                'syntax' => 'short',
+            ],
+            'no_unreachable_default_argument_value' => false,
+            'braces' => [
+                'allow_single_line_closure' => true,
+            ],
+            'heredoc_to_nowdoc' => false,
+            'phpdoc_summary' => false,
+            'increment_style' => ['style' => 'post'],
+            'yoda_style' => false,
+            'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        ];
+
+        return $rules;
+    }
+}

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace M6Web\CS\Config;
+
+use PhpCsFixer\Config;
+
+final class Php73 extends Config
+{
+    public function __construct()
+    {
+        parent::__construct('M6Web (PHP 7.3)');
+
+        $this->setRiskyAllowed(true);
+    }
+
+    public function getRules()
+    {
+        $rules = [
+            '@Symfony' => true,
+            'array_syntax' => [
+                'syntax' => 'short',
+            ],
+            'no_unreachable_default_argument_value' => false,
+            'braces' => [
+                'allow_single_line_closure' => true,
+            ],
+            'heredoc_to_nowdoc' => false,
+            'phpdoc_summary' => false,
+            'increment_style' => ['style' => 'post'],
+            'yoda_style' => false,
+            'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        ];
+
+        return $rules;
+    }
+}


### PR DESCRIPTION
Although code style 7.1 is compatible with newer versions, it's cleaner to have dedicated configuration to match potential Php new features.

* Dummy copy/paster
* Composer update to support [Php 7.3 in Cs-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.14.0)