### PR TITLE
feat: Add rule for phpdoc in single line

### DIFF
--- a/src/Php71.php
+++ b/src/Php71.php
@@ -29,6 +29,10 @@ final class Php71 extends Config
             'increment_style' => ['style' => 'post'],
             'yoda_style' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
+            'phpdoc_line_span' => [
+                'property' => 'single',
+                'const' => 'single',
+            ],
         ];
 
         return $rules;

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -29,6 +29,10 @@ final class Php72 extends Config
             'increment_style' => ['style' => 'post'],
             'yoda_style' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
+            'phpdoc_line_span' => [
+                'property' => 'single',
+                'const' => 'single',
+            ],
         ];
 
         return $rules;

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -29,6 +29,10 @@ final class Php73 extends Config
             'increment_style' => ['style' => 'post'],
             'yoda_style' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
+            'phpdoc_line_span' => [
+                'property' => 'single',
+                'const' => 'single',
+            ],
         ];
 
         return $rules;

--- a/src/Php74.php
+++ b/src/Php74.php
@@ -29,6 +29,10 @@ final class Php74 extends Config
             'increment_style' => ['style' => 'post'],
             'yoda_style' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
+            'phpdoc_line_span' => [
+                'property' => 'single',
+                'const' => 'single',
+            ],
         ];
 
         return $rules;


### PR DESCRIPTION
Add rules to prefer single line on phpDoc for properties and const.

**Example :** 
```
<?php
class Foo{
-    /**
-    * @const string
-    */
+    /** @const string */
    const VAR='foo';
-    /**
-    * @var bool
-    */
+    /** @var bool */
    public $var;
 }

```