### PR TITLE
feat: Don't force single line throw

### DIFF
--- a/src/Php71.php
+++ b/src/Php71.php
@@ -33,6 +33,7 @@ final class Php71 extends Config
                 'property' => 'single',
                 'const' => 'single',
             ],
+            'single_line_throw' => false,
         ];
 
         return $rules;

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -33,6 +33,7 @@ final class Php72 extends Config
                 'property' => 'single',
                 'const' => 'single',
             ],
+            'single_line_throw' => false,
         ];
 
         return $rules;

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -33,6 +33,7 @@ final class Php73 extends Config
                 'property' => 'single',
                 'const' => 'single',
             ],
+            'single_line_throw' => false,
         ];
 
         return $rules;

--- a/src/Php74.php
+++ b/src/Php74.php
@@ -33,6 +33,7 @@ final class Php74 extends Config
                 'property' => 'single',
                 'const' => 'single',
             ],
+            'single_line_throw' => false,
         ];
 
         return $rules;


### PR DESCRIPTION
Set `single_line_throw` to `false` to be able to choose to throw exceptions on one or many lines

### Actual
```
throw new ApiException("[{$e->getCode()}] {$e->getMessage()}", $e->getCode(), !is_null($e->getResponse()) ? $e->getResponse()->getHeaders() : [], !is_null($e->getResponse()) ? $e->getResponse()->getBody()->__toString() : null); 
```

### Wanted
```
throw new ApiException(
        "[{$e->getCode()}] {$e->getMessage()}",
        $e->getCode(), 
        !is_null($e->getResponse()) ? $e->getResponse()->getHeaders() : [], 
        !is_null($e->getResponse()) ? $e->getResponse()->getBody()->__toString() : null
);
```
