### PR TITLE
Single version and cs-fixer 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,32 @@ $ composer require --dev m6web/php-cs-fixer-config
 
 ### Configuration
 
-Create a configuration file `.php_cs` in the root of your project:
+Create a configuration file `.php-cs-fixer.dist.php` in the root of your project:
 
 ```php
 <?php
 
-$config = new M6Web\CS\Config\Php72;
+$finder = PhpCsFixer\Finder::create()
+    ->in(
+        [
+            __DIR__.'/src',
+            __DIR__.'/tests',
+        ]
+    );
 
-$config->getFinder()
-    ->in([
-        __DIR__.'/src'
-    ])->exclude([
-        'Tests'
-    ]);
+$config = new M6Web\CS\Config\BedrockStreaming();
+$config->setFinder($finder);
 
 return $config;
 ```
 
 ### Git
 
-Add `.php_cs.cache` (this is the cache file created by `php-cs-fixer`) to `.gitignore`:
+Add `.php-cs-fixer.cache` (this is the cache file created by `php-cs-fixer`) to `.gitignore`:
 
 ```
 vendor/
-.php_cs.cache
+.php-cs-fixer.cache
 ```
 
 ### Makefile
@@ -81,7 +83,7 @@ $ make cs-ci
 
 ## Credits
 
-Developed by [M6Web](http://tech.m6web.fr/), inspired by [refinery29/php-cs-fixer-config](https://github.com/refinery29/php-cs-fixer-config).
+Developed by [Bedrock Streaming](https://tech.bedrockstreaming.com), inspired by [refinery29/php-cs-fixer-config](https://github.com/refinery29/php-cs-fixer-config).
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "M6Web",
-            "email": "opensource@m6web.fr",
-            "homepage": "http://tech.m6web.fr/"
+            "name": "Bedrock",
+            "email": "opensource@bedrockstreaming.com",
+            "homepage": "https://tech.bedrockstreaming.com/"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "friendsofphp/php-cs-fixer": "^2.16.1"
+        "php": "^7.1.3 || ^8.0",
+        "friendsofphp/php-cs-fixer": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -23,6 +23,11 @@ final class BedrockStreaming extends Config
             'braces' => [
                 'allow_single_line_closure' => true,
             ],
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'heredoc_to_nowdoc' => false,
             'increment_style' => ['style' => 'post'],
             'no_unreachable_default_argument_value' => false,
@@ -32,6 +37,7 @@ final class BedrockStreaming extends Config
                 'const' => 'single',
             ],
             'phpdoc_summary' => false,
+            'single_line_throw' => false,
             'yoda_style' => false,
         ];
 

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -4,14 +4,11 @@ namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;
 
-/**
- * @deprecated Use M6Web\CS\Config\BedrockStreaming
- */
-final class Php71 extends Config
+final class BedrockStreaming extends Config
 {
     public function __construct()
     {
-        parent::__construct('M6Web (PHP 7.1)');
+        parent::__construct('Bedrock Streaming');
 
         $this->setRiskyAllowed(true);
     }

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -13,7 +13,7 @@ final class BedrockStreaming extends Config
         $this->setRiskyAllowed(true);
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         $rules = [
             '@Symfony' => true,

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -20,19 +20,19 @@ final class BedrockStreaming extends Config
             'array_syntax' => [
                 'syntax' => 'short',
             ],
-            'no_unreachable_default_argument_value' => false,
             'braces' => [
                 'allow_single_line_closure' => true,
             ],
             'heredoc_to_nowdoc' => false,
-            'phpdoc_summary' => false,
             'increment_style' => ['style' => 'post'],
-            'yoda_style' => false,
+            'no_unreachable_default_argument_value' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
             'phpdoc_line_span' => [
                 'property' => 'single',
                 'const' => 'single',
             ],
+            'phpdoc_summary' => false,
+            'yoda_style' => false,
         ];
 
         return $rules;

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -16,7 +16,7 @@ final class Php71 extends Config
         $this->setRiskyAllowed(true);
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         $rules = [
             '@Symfony' => true,

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -16,7 +16,7 @@ final class Php72 extends Config
         $this->setRiskyAllowed(true);
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         $rules = [
             '@Symfony' => true,

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -4,6 +4,9 @@ namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;
 
+/**
+ * @deprecated Use M6Web\CS\Config\BedrockStreaming
+ */
 final class Php72 extends Config
 {
     public function __construct()

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -16,7 +16,7 @@ final class Php73 extends Config
         $this->setRiskyAllowed(true);
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         $rules = [
             '@Symfony' => true,

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -4,6 +4,9 @@ namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;
 
+/**
+ * @deprecated Use M6Web\CS\Config\BedrockStreaming
+ */
 final class Php73 extends Config
 {
     public function __construct()

--- a/src/Php74.php
+++ b/src/Php74.php
@@ -16,7 +16,7 @@ final class Php74 extends Config
         $this->setRiskyAllowed(true);
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         $rules = [
             '@Symfony' => true,

--- a/src/Php74.php
+++ b/src/Php74.php
@@ -4,6 +4,9 @@ namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;
 
+/**
+ * @deprecated Use M6Web\CS\Config\BedrockStreaming
+ */
 final class Php74 extends Config
 {
     public function __construct()


### PR DESCRIPTION
Here is a proposal to use a single Code Style file instead of keeping multiple identical files.


## Changes 
* Deprecation of old PhpXY code stule files
* Use a single BedrockStreaming set of rules.
* Bumped the version of php-cs-fixer. **This will require a major version.**
* Add a set of rules to prevent importing every classes/constants/functions
* Included the changes from @FloFrad #16 to allow multi line throw