### PR TITLE
add rule 'declare_strict_types' => true

### DIFF
--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;
@@ -23,6 +25,7 @@ final class BedrockStreaming extends Config
             'braces' => [
                 'allow_single_line_closure' => true,
             ],
+            'declare_strict_types' => true,
             'global_namespace_import' => [
                 'import_classes' => false,
                 'import_constants' => false,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;

--- a/src/Php73.php
+++ b/src/Php73.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;

--- a/src/Php74.php
+++ b/src/Php74.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace M6Web\CS\Config;
 
 use PhpCsFixer\Config;


### PR DESCRIPTION
Adding this rule via cs-fixer following a common decision (internal RFC).
This will prevent some oversights and help us to use php strict typing.
