### PR TITLE
feat: authorize adding extra rules, no override allowed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
           php-version: ${{ matrix.php-version }}
       - run: composer install --prefer-dist --no-interaction
       - run: vendor/bin/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose
+      - run: vendor/bin/phpunit --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 composer.lock
+*.phar
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ $config->setFinder($finder);
 return $config;
 ```
 
+#### Adding extra rules:
+
+In case you wish to add some more rules (be more restrictive / apply project level rules), the `M6Web\CS\Config\BedrockStreaming` configuration accepts them as a constructor argument.
+
+⚠️ This feature does not allow any override. ⚠️
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(
+        [
+            __DIR__.'/src',
+            __DIR__.'/tests',
+        ]
+    );
+
+$config = new M6Web\CS\Config\BedrockStreaming([
+        'native_function_invocation' => ['scope' => 'all'],
+    ]
+);
+$config->setFinder($finder);
+
+return $config;
+```
+
+
 ### Git
 
 Add `.php-cs-fixer.cache` (this is the cache file created by `php-cs-fixer`) to `.gitignore`:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.1",
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -8,16 +8,20 @@ use PhpCsFixer\Config;
 
 final class BedrockStreaming extends Config
 {
-    public function __construct()
+    /** @var array */
+    private $extraRules;
+
+    public function __construct(array $extraRules = [])
     {
         parent::__construct('Bedrock Streaming');
 
+        $this->extraRules = $extraRules;
         $this->setRiskyAllowed(true);
     }
 
     public function getRules(): array
     {
-        $rules = [
+        $standardRules = [
             '@Symfony' => true,
             'array_syntax' => [
                 'syntax' => 'short',
@@ -46,6 +50,8 @@ final class BedrockStreaming extends Config
             'yoda_style' => false,
         ];
 
-        return $rules;
+        $newRules = \array_diff_key($this->extraRules, $standardRules);
+
+        return \array_merge($newRules, $standardRules);
     }
 }

--- a/tests/BedrockStreamingTest.php
+++ b/tests/BedrockStreamingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use M6Web\CS\Config\BedrockStreaming;
+use PHPUnit\Framework\TestCase;
+
+class BedrockStreamingTest extends TestCase
+{
+    /**
+     * @test
+     * @covers M6Web\CS\Config\BedrockStreaming::getRules
+     */
+    public function RulesOrderShoulNotBeAltered()
+    {
+        $extraRules = [
+            'braces' => [
+                'allow_single_line_closure' => false,
+            ],
+            'dummy_rule' => 'dummy_value',
+            '@Symfony' => false,
+        ];
+        $rules = (new BedrockStreaming($extraRules))->getRules();
+
+        self::assertEquals('array', gettype($rules));
+
+        // Make sure the new rule is added before the standard ones to prevent any regression
+        $firstValue = reset($rules);
+        $firstKey = key($rules);
+        self::assertEquals('dummy_rule', $firstKey, 'The new rules should be added before standard ones');
+        self::assertEquals('dummy_value', $firstValue);
+
+        // Make sure the first standard rule comes after the custom rules
+        self::assertArrayHasKey('@Symfony', $rules, 'The @Symfony rule should not be deleted');
+        $nextValue = next($rules);
+        $nextKey = key($rules);
+        self::assertEquals('@Symfony', $nextKey, 'The first rule should always remain @Symfony');
+        self::assertTrue($nextValue, 'The standard root rules value should never change');
+
+        // Make sure a nested rule cannot be overriden
+        self::assertArrayHasKey('braces', $rules);
+        self::assertArrayHasKey('allow_single_line_closure', $rules['braces']);
+        self::assertTrue($rules['braces']['allow_single_line_closure'], 'The standard nested rules should never change');
+    }
+}


### PR DESCRIPTION
## Why?
As this config user
I want to be able to add custom rules
And make sure the standard rules are never overriden
In order to share the same cs-fixer rules with the company and, optionnaly, my team's more restrictive ones

## TODO
- [x] code is tested
- [x] documentation is updated (if needed)
