### PR TITLE
feat(cs-config, performance): add native_function_invocation rule

### DIFF
--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -33,6 +33,7 @@ final class BedrockStreaming extends Config
             ],
             'heredoc_to_nowdoc' => false,
             'increment_style' => ['style' => 'post'],
+            'native_function_invocation' => ['strict' => false],
             'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
             'no_unreachable_default_argument_value' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],


### PR DESCRIPTION
## Why?
`native_function_invocation` rule adds leading `\` before function invocation to speed up resolving.

refer to [the rule documentation](https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html#using-this-rule-is-risky)

`strict` parameter is set to false to keep the leading `\`in case it is not necessary. (Limits the amount of fixes)

:warning: this rule is risky in case native function rules are overriden (implies a major version)

Example:

```php
--- Original
+++ New
 <?php

 function baz($options)
 {
-    if (!array_key_exists("foo", $options)) {
+    if (!\array_key_exists("foo", $options)) {
         throw new \InvalidArgumentException();
     }

     return json_encode($options);
 }
```

### Why setting strict parameter false ?

true value (default): The unnecessary leading `\` are removed 

```php
--- Original
+++ New
 <?php

 function baz($options)
 {
-     return \json_encode($options);
+     return json_encode($options);

 }
```

false value: The unnecessary leading `\` are kept. One can chosse to keep it or not.

```php
--- Original
+++ New
 <?php

 function baz($options)
 {
     return \json_encode($options);
 }
```

## TODO
- [ ] code is tested (locally)
- [ ] documentation is updated (if needed)
