### PR TITLE
feat(cs-config): add no_superfluous_phpdoc_tags rule without allow_unused_params

### DIFF
--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -33,6 +33,7 @@ final class BedrockStreaming extends Config
             ],
             'heredoc_to_nowdoc' => false,
             'increment_style' => ['style' => 'post'],
+            'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
             'no_unreachable_default_argument_value' => false,
             'ordered_imports' => ['sort_algorithm' => 'alpha'],
             'phpdoc_line_span' => [


### PR DESCRIPTION
## Why?
The current `@Symfony` used rule set enables this rule:

```php
'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'allow_unused_params' => true]
```

We propose not to allow unused params (dead code dock blocks removed).

### Explanation:

Current behavior:

```php
--- Original
+++ New
 <?php
 class Foo {
     /**
-     * @param Bar $bar
-     * @param mixed $baz
      * @param string|int|null $qux
      */
     public function doFoo(Bar $bar, $baz /*, $qux = null */) {}
 }
```

Future:

```php
--- Original
+++ New
 <?php
 class Foo {
     /**
-     * @param Bar $bar
-     * @param mixed $baz
-     * @param string|int|null $qux
      */
     public function doFoo(Bar $bar, $baz /*, $qux = null */) {}
 }
```

## TODO
- [ ] code is tested
- [ ] documentation is updated (if needed)
