### PR TITLE
fix: remove braces rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.16"
     },
     "autoload": {
         "psr-4": {

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -22,9 +22,6 @@ final class BedrockStreaming extends Config
             'array_syntax' => [
                 'syntax' => 'short',
             ],
-            'braces' => [
-                'allow_single_line_closure' => true,
-            ],
             'declare_strict_types' => true,
             'global_namespace_import' => [
                 'import_classes' => false,


### PR DESCRIPTION
## Why?

The ```braces``` rule has been deprecated since version 3.16 of PHP-CS-Fixer so it must be removed and replaced by its equivalents. 
However, those rules ("single_space_around_construct", "control_structure_braces", "curly_braces_position", "control_structure_continuation_position", "declare_parentheses", "statement_indentation", "no_multiple_statements_per_line" and "no_extra_blank_lines") are already enabled in PHP-CS-Fixer.
In addition, the`friendsofphp/php-cs-fixer` version must be changed to 3.16 minimum, since one of the rules,`single_space_around_construct` becomes usable from this version.
