### PR TITLE
feat: improve php-cs rules with PSR-12 and `trailing_comma_in_multiline`

### DIFF
--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -18,6 +18,7 @@ final class BedrockStreaming extends Config
     public function getRules(): array
     {
         $rules = [
+            '@PSR12' => true,
             '@Symfony' => true,
             'array_syntax' => [
                 'syntax' => 'short',
@@ -41,6 +42,7 @@ final class BedrockStreaming extends Config
             'phpdoc_summary' => false,
             'single_line_throw' => false,
             'yoda_style' => false,
+            'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
         ];
 
         return $rules;


### PR DESCRIPTION
## Why?
PHP-CS supports now PSR-12 rules. 

To avoid unnecessary changes in PRs with only commas added on multi-lines declarations, I propose adding the `trailing_comma_in_multiline rule`.

## TODO
- [ ] code is tested
- [ ] documentation is updated (if needed)
