### PR TITLE
fix: remove trailing_comma_in_multiline because it's not work with PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linter:

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -42,7 +42,6 @@ final class BedrockStreaming extends Config
             'phpdoc_summary' => false,
             'single_line_throw' => false,
             'yoda_style' => false,
-            'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
         ];
 
         return $rules;


### PR DESCRIPTION
## Why?
PHP 7.4 does not support comma on last entry for method parameters and `match`

## TODO
- [x] code is tested
- [x] documentation is updated (if needed)
