### PR TITLE
feat: support PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   linter:
     name: Code style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -17,12 +17,10 @@ final class BedrockStreaming extends Config
 
     public function getRules(): array
     {
-        $rules = [
+        return [
             '@PSR12' => true,
             '@Symfony' => true,
-            'array_syntax' => [
-                'syntax' => 'short',
-            ],
+            'array_syntax' => true,
             'declare_strict_types' => true,
             'global_namespace_import' => [
                 'import_classes' => false,
@@ -42,9 +40,19 @@ final class BedrockStreaming extends Config
             'phpdoc_summary' => false,
             'single_line_throw' => false,
             'yoda_style' => false,
-            'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
+            'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters', 'array_destructuring']],
+            'simple_to_complex_string_variable' => true,
+            'no_unset_cast' => true,
+            'clean_namespace' => true,
+            'short_scalar_cast' => true,
+            'normalize_index_brace' => true,
+            'assign_null_coalescing_to_coalesce_equal' => true,
+            'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
+            'method_argument_space' => ['after_heredoc' => true, 'on_multiline' => 'ensure_fully_multiline', 'attribute_placement' => 'ignore'],
+            'heredoc_indentation' => true,
+            'visibility_required' => true,
+            'list_syntax' => true,
+            'ternary_to_null_coalescing' => true,
         ];
-
-        return $rules;
     }
 }


### PR DESCRIPTION
## Why?
`friendsofphp/php-cs-fixer` now support PHP 8.4 from version 3.80.0 🎉

A `composer update` is enough to run this package on PHP 8.4.

Rules has been updated after testing the rule set `@PHP84Migration`. Some existing rules have been updated, and new rules are coming to complement them.

## TODO
- [x] code is tested
- [x] documentation is updated (if needed)
