### PR TITLE
Replace 'visibility_required' with 'modifier_keywords'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.57"
+        "friendsofphp/php-cs-fixer": "^3.88"
     },
     "autoload": {
         "psr-4": {

--- a/src/BedrockStreaming.php
+++ b/src/BedrockStreaming.php
@@ -50,7 +50,7 @@ final class BedrockStreaming extends Config
             'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
             'method_argument_space' => ['after_heredoc' => true, 'on_multiline' => 'ensure_fully_multiline', 'attribute_placement' => 'ignore'],
             'heredoc_indentation' => true,
-            'visibility_required' => true,
+            'modifier_keywords' => ['elements' => ['const, 'method', 'property']],
             'list_syntax' => true,
             'ternary_to_null_coalescing' => true,
         ];


### PR DESCRIPTION
This rule is deprecated and will be removed in the next major version

You should use modifier_keywords instead.
https://cs.symfony.com/doc/rules/class_notation/visibility_required.html