### PR TITLE
feat: support PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.57"
+        "friendsofphp/php-cs-fixer": "^3.93"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Why?
`friendsofphp/php-cs-fixer` now support PHP 8.5 from version 3.91.0 🎉

## TODO
- [ ] code is tested
- [x] documentation is updated (if needed)
